### PR TITLE
Add static Suika game UI

### DIFF
--- a/next-app/app/games/suika/design.css
+++ b/next-app/app/games/suika/design.css
@@ -1,4 +1,4 @@
-.suika-page {
+.suika-game {
     margin: 0;
     font-family: sans-serif;
     background-color: #f5f0e6;
@@ -9,21 +9,21 @@
     height: 100vh;
 }
 
-.suika-page .game-wrapper {
+.suika-game .game-wrapper {
     width: 320px;
     height: 600px;
     margin-top: 20px;
     position: relative;
 }
 
-.suika-page .scoreboard {
+.suika-game .scoreboard {
     display: flex;
     justify-content: center;
     gap: 16px;
     margin-bottom: 16px;
 }
 
-.suika-page .bubble {
+.suika-game .bubble {
     width: 60px;
     height: 60px;
     border-radius: 50%;
@@ -35,12 +35,11 @@
     font-weight: bold;
 }
 
-.suika-page .bubble--next .icon::before {
-    content: "\1F353";
+.suika-game .bubble--next .icon {
     font-size: 24px;
 }
 
-.suika-page .glass-box {
+.suika-game .glass-box {
     width: 300px;
     height: 400px;
     margin: 0 auto;
@@ -51,7 +50,7 @@
     position: relative;
 }
 
-.suika-page .fruit {
+.suika-game .fruit {
     width: 40px;
     height: 40px;
     border-radius: 50%;
@@ -64,14 +63,14 @@
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
 
-.suika-page .fruit--watermelon { background-color: #FF4B4B; }
-.suika-page .fruit--strawberry { background-color: #FF6677; }
-.suika-page .fruit--orange { background-color: #FFA433; }
-.suika-page .fruit--grape { background-color: #AA55FF; }
-.suika-page .fruit--lemon { background-color: #FFEE66; color: #333; }
+.suika-game .fruit--watermelon { background-color: #FF4B4B; }
+.suika-game .fruit--strawberry { background-color: #FF6677; }
+.suika-game .fruit--orange { background-color: #FFA433; }
+.suika-game .fruit--grape { background-color: #AA55FF; }
+.suika-game .fruit--lemon { background-color: #FFEE66; color: #333; }
 
-.suika-page .fruit--watermelon::before { content: "\1F349"; }
-.suika-page .fruit--strawberry::before { content: "\1F353"; }
-.suika-page .fruit--orange::before { content: "\1F34A"; }
-.suika-page .fruit--grape::before { content: "\1F347"; }
-.suika-page .fruit--lemon::before { content: "\1F34B"; }
+.suika-game .fruit--watermelon::before { content: "\1F349"; }
+.suika-game .fruit--strawberry::before { content: "\1F353"; }
+.suika-game .fruit--orange::before { content: "\1F34A"; }
+.suika-game .fruit--grape::before { content: "\1F347"; }
+.suika-game .fruit--lemon::before { content: "\1F34B"; }

--- a/next-app/app/games/suika/design.css
+++ b/next-app/app/games/suika/design.css
@@ -1,0 +1,77 @@
+.suika-page {
+    margin: 0;
+    font-family: sans-serif;
+    background-color: #f5f0e6;
+    background-image: repeating-linear-gradient(45deg, #f5f0e6 0, #f5f0e6 20px, #e9e0d1 20px, #e9e0d1 40px);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    height: 100vh;
+}
+
+.suika-page .game-wrapper {
+    width: 320px;
+    height: 600px;
+    margin-top: 20px;
+    position: relative;
+}
+
+.suika-page .scoreboard {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.suika-page .bubble {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.9), rgba(255,255,255,0.6));
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #333;
+    font-weight: bold;
+}
+
+.suika-page .bubble--next .icon::before {
+    content: "\1F353";
+    font-size: 24px;
+}
+
+.suika-page .glass-box {
+    width: 300px;
+    height: 400px;
+    margin: 0 auto;
+    background: rgba(255,255,255,0.2);
+    border: 2px solid rgba(255,255,255,0.5);
+    border-radius: 8px;
+    box-shadow: inset 0 0 10px rgba(0,0,0,0.1);
+    position: relative;
+}
+
+.suika-page .fruit {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #fff;
+    font-size: 24px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.suika-page .fruit--watermelon { background-color: #FF4B4B; }
+.suika-page .fruit--strawberry { background-color: #FF6677; }
+.suika-page .fruit--orange { background-color: #FFA433; }
+.suika-page .fruit--grape { background-color: #AA55FF; }
+.suika-page .fruit--lemon { background-color: #FFEE66; color: #333; }
+
+.suika-page .fruit--watermelon::before { content: "\1F349"; }
+.suika-page .fruit--strawberry::before { content: "\1F353"; }
+.suika-page .fruit--orange::before { content: "\1F34A"; }
+.suika-page .fruit--grape::before { content: "\1F347"; }
+.suika-page .fruit--lemon::before { content: "\1F34B"; }

--- a/next-app/app/games/suika/page.tsx
+++ b/next-app/app/games/suika/page.tsx
@@ -1,39 +1,10 @@
+"use client";
+export const dynamic = "force-dynamic";
+import dynamicFn from "next/dynamic";
 import "./design.css";
 
-export default function SuikaDesignPage() {
-  return (
-    <div className="suika-page">
-      <div className="game-wrapper">
-        <div className="scoreboard">
-          <div className="bubble bubble--best">2347</div>
-          <div className="bubble bubble--score">684</div>
-          <div className="bubble bubble--next">
-            <span className="icon" />
-          </div>
-        </div>
-        <div className="glass-box">
-          <div
-            className="fruit fruit--watermelon"
-            style={{ left: "50px", top: "220px" }}
-          />
-          <div
-            className="fruit fruit--orange"
-            style={{ left: "120px", top: "180px", zIndex: 2 }}
-          />
-          <div
-            className="fruit fruit--grape"
-            style={{ left: "180px", top: "240px", zIndex: 3 }}
-          />
-          <div
-            className="fruit fruit--lemon"
-            style={{ left: "140px", top: "120px" }}
-          />
-          <div
-            className="fruit fruit--strawberry"
-            style={{ left: "90px", top: "80px", zIndex: 4 }}
-          />
-        </div>
-      </div>
-    </div>
-  );
+const Game = dynamicFn(() => import("@/components/Game"), { ssr: false });
+
+export default function GamePage() {
+  return <Game />;
 }

--- a/next-app/app/games/suika/page.tsx
+++ b/next-app/app/games/suika/page.tsx
@@ -1,10 +1,39 @@
-"use client";
-export const dynamic = "force-dynamic";
-import dynamicFn from "next/dynamic";
+import "./design.css";
 
-const Game = dynamicFn(() => import("@/components/Game"), { ssr: false });
-
-export default function GamePage() {
-  return <Game />;
+export default function SuikaDesignPage() {
+  return (
+    <div className="suika-page">
+      <div className="game-wrapper">
+        <div className="scoreboard">
+          <div className="bubble bubble--best">2347</div>
+          <div className="bubble bubble--score">684</div>
+          <div className="bubble bubble--next">
+            <span className="icon" />
+          </div>
+        </div>
+        <div className="glass-box">
+          <div
+            className="fruit fruit--watermelon"
+            style={{ left: "50px", top: "220px" }}
+          />
+          <div
+            className="fruit fruit--orange"
+            style={{ left: "120px", top: "180px", zIndex: 2 }}
+          />
+          <div
+            className="fruit fruit--grape"
+            style={{ left: "180px", top: "240px", zIndex: 3 }}
+          />
+          <div
+            className="fruit fruit--lemon"
+            style={{ left: "140px", top: "120px" }}
+          />
+          <div
+            className="fruit fruit--strawberry"
+            style={{ left: "90px", top: "80px", zIndex: 4 }}
+          />
+        </div>
+      </div>
+    </div>
+  );
 }
-

--- a/next-app/components/Game.tsx
+++ b/next-app/components/Game.tsx
@@ -110,11 +110,10 @@ export default function Game() {
           className="board glass-box"
           onPointerDown={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();
+            // Use pointer events for both mouse and touch to avoid duplicate
+            // drops that can occur when `touchstart` and `pointerdown` fire
+            // together on mobile browsers.
             drop(e.clientX - rect.left);
-          }}
-          onTouchStart={(e) => {
-            const rect = e.currentTarget.getBoundingClientRect();
-            drop(e.touches[0].clientX - rect.left);
           }}
         />
       {over && (

--- a/next-app/components/Game.tsx
+++ b/next-app/components/Game.tsx
@@ -4,17 +4,20 @@ import Link from "next/link";
 import { createEmojiPhysics, TIERS, type PhysicsHandle } from "./EmojiPhysics";
 import "../styles/game.css";
 
+const BEST_KEY = "suika-best";
+
 export default function Game() {
   const boardRef = useRef<HTMLDivElement>(null);
   const physics = useRef<PhysicsHandle | null>(null);
   const [score, setScore] = useState(0);
-  const [progress, setProgress] = useState(0);
+  const [best, setBest] = useState(0);
   const [over, setOver] = useState(false);
   const [nextTier, setNextTier] = useState(0);
 
   // daily seed rng
   const rng = useRef<() => number>(() => 0);
   useEffect(() => {
+    setBest(Number(localStorage.getItem(BEST_KEY) || 0));
     let seed = Number(new Date().toISOString().slice(0, 10).replace(/-/g, ""));
     const rand = () => {
       seed = (seed * 9301 + 49297) % 233280;
@@ -23,6 +26,17 @@ export default function Game() {
     rng.current = rand;
     setNextTier(Math.floor(rand() * 8));
   }, []);
+
+  // update best score when game over
+  useEffect(() => {
+    if (over) {
+      setBest((b) => {
+        const next = Math.max(b, score);
+        localStorage.setItem(BEST_KEY, String(next));
+        return next;
+      });
+    }
+  }, [over, score]);
 
   useEffect(() => {
     if (!boardRef.current) return;
@@ -46,7 +60,6 @@ export default function Game() {
     const step = () => {
       if (physics.current) {
         physics.current.update();
-        setProgress(physics.current.getHeight());
       }
       id = requestAnimationFrame(step);
     };
@@ -83,38 +96,37 @@ export default function Game() {
   };
 
   return (
-    <div className="game-wrapper">
-      <header className="header">
-        <span>🏅 {score}</span>
-        <span className="next">{TIERS[nextTier]}</span>
-        <div className="progress">
-          <div
-            className="progress-inner"
-            style={{ width: `${Math.min(progress * 100, 100)}%` }}
-          />
+    <div className="suika-game">
+      <div className="game-wrapper">
+        <div className="scoreboard">
+          <div className="bubble bubble--best">{best}</div>
+          <div className="bubble bubble--score">{score}</div>
+          <div className="bubble bubble--next">
+            <span className="icon">{TIERS[nextTier]}</span>
+          </div>
         </div>
-      </header>
-      <div
-        ref={boardRef}
-        className="board"
-        onPointerDown={(e) => {
-          const rect = e.currentTarget.getBoundingClientRect();
-          drop(e.clientX - rect.left);
-        }}
-        onTouchStart={(e) => {
-          const rect = e.currentTarget.getBoundingClientRect();
-          drop(e.touches[0].clientX - rect.left);
-        }}
-      />
+        <div
+          ref={boardRef}
+          className="board glass-box"
+          onPointerDown={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            drop(e.clientX - rect.left);
+          }}
+          onTouchStart={(e) => {
+            const rect = e.currentTarget.getBoundingClientRect();
+            drop(e.touches[0].clientX - rect.left);
+          }}
+        />
       {over && (
         <div className="modal">
           <p className="mb-2">Score: {score}</p>
           <button onClick={reset} className="mb-2">Restart</button>
         </div>
       )}
-      <footer className="footer">
-        © <Link href="/">Home</Link>
-      </footer>
+        <footer className="footer">
+          © <Link href="/">Home</Link>
+        </footer>
+      </div>
     </div>
   );
 }

--- a/suika-game/index.html
+++ b/suika-game/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>スイカゲーム UI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="game-wrapper">
+        <div class="scoreboard">
+            <div class="bubble bubble--best">2347</div>
+            <div class="bubble bubble--score">684</div>
+            <div class="bubble bubble--next">
+                <span class="icon icon--strawberry"></span>
+            </div>
+        </div>
+        <div class="glass-box">
+            <div class="fruit fruit--watermelon" style="left: 50px; top: 220px;"></div>
+            <div class="fruit fruit--orange" style="left: 120px; top: 180px; z-index:2;"></div>
+            <div class="fruit fruit--grape" style="left: 180px; top: 240px; z-index:3;"></div>
+            <div class="fruit fruit--lemon" style="left: 140px; top: 120px;"></div>
+            <div class="fruit fruit--strawberry" style="left: 90px; top: 80px; z-index:4;"></div>
+        </div>
+    </div>
+</body>
+</html>

--- a/suika-game/style.css
+++ b/suika-game/style.css
@@ -1,0 +1,78 @@
+body {
+    margin: 0;
+    font-family: sans-serif;
+    background-color: #f5f0e6;
+    background-image: repeating-linear-gradient(45deg, #f5f0e6 0, #f5f0e6 20px, #e9e0d1 20px, #e9e0d1 40px);
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    height: 100vh;
+}
+
+.game-wrapper {
+    width: 320px;
+    height: 600px;
+    margin-top: 20px;
+    position: relative;
+}
+
+.scoreboard {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    margin-bottom: 16px;
+}
+
+.bubble {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.9), rgba(255,255,255,0.6));
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #333;
+    font-weight: bold;
+}
+
+.bubble--next .icon::before {
+    content: "\1F353";
+    font-size: 24px;
+}
+
+.glass-box {
+    width: 300px;
+    height: 400px;
+    margin: 0 auto;
+    background: rgba(255,255,255,0.2);
+    border: 2px solid rgba(255,255,255,0.5);
+    border-radius: 8px;
+    box-shadow: inset 0 0 10px rgba(0,0,0,0.1);
+    position: relative;
+}
+
+.fruit {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #fff;
+    font-size: 24px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+
+.fruit--watermelon { background-color: #FF4B4B; }
+.fruit--strawberry { background-color: #FF6677; }
+.fruit--orange { background-color: #FFA433; }
+.fruit--grape { background-color: #AA55FF; }
+.fruit--lemon { background-color: #FFEE66; color: #333; }
+
+.fruit--watermelon::before { content: "\1F349"; }
+.fruit--strawberry::before { content: "\1F353"; }
+.fruit--orange::before { content: "\1F34A"; }
+.fruit--grape::before { content: "\1F347"; }
+.fruit--lemon::before { content: "\1F34B"; }
+


### PR DESCRIPTION
## Summary
- add simple HTML layout for Suika game replica
- style score bubbles, glass box, and fruits with CSS only

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d08ce4f88324b8f14b3453e1f127