### PR TITLE
Adjust game layout and add logo

### DIFF
--- a/next-app/app/games/suika/design.css
+++ b/next-app/app/games/suika/design.css
@@ -10,8 +10,8 @@
 }
 
 .suika-game .game-wrapper {
-    width: 320px;
-    height: 600px;
+    width: 480px;
+    height: 800px;
     margin-top: 20px;
     position: relative;
 }
@@ -24,8 +24,8 @@
 }
 
 .suika-game .bubble {
-    width: 60px;
-    height: 60px;
+    width: 80px;
+    height: 80px;
     border-radius: 50%;
     background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.9), rgba(255,255,255,0.6));
     display: flex;
@@ -40,8 +40,8 @@
 }
 
 .suika-game .glass-box {
-    width: 300px;
-    height: 400px;
+    width: 450px;
+    height: 600px;
     margin: 0 auto;
     background: rgba(255,255,255,0.2);
     border: 2px solid rgba(255,255,255,0.5);

--- a/next-app/app/layout.tsx
+++ b/next-app/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Image from "next/image";
+import Link from "next/link";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -27,6 +29,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <header className="py-4 text-center border-b">
+          <Link href="/">
+            <Image src="/logo.svg" width={120} height={40} alt="Logo" />
+          </Link>
+        </header>
         {children}
       </body>
     </html>

--- a/next-app/public/logo.svg
+++ b/next-app/public/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40">
+  <rect width="120" height="40" rx="8" fill="#16a34a" />
+  <text x="60" y="26" font-size="20" text-anchor="middle" fill="white" font-family="Arial, Helvetica, sans-serif">Suika</text>
+</svg>

--- a/next-app/styles/game.css
+++ b/next-app/styles/game.css
@@ -37,7 +37,7 @@
 
 .board {
   width: 95vw;
-  max-width: 420px;
+  max-width: 600px;
   aspect-ratio: 1 / 1;
   background: #111;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- enlarge the suika game board size
- add a simple logo to the global header

## Testing
- `npm run lint` *(fails: interactive prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850f4f5a15483249eb8a2a209f10b29