### PR TITLE
Add Monster Strike style mini game

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 This repository contains example web apps. The `next-app` directory is a [Next.js](https://nextjs.org/) application ready to deploy on [Vercel](https://vercel.com/).
 
+## Static game demos
+
+- `suika-game`: a UI mock of the fruit-merging puzzle.
+- `monst-game`: a simple drag-launch mini game inspired by Monster Strike.
+
+
 ## Development
 
 ```bash

--- a/monst-game/index.html
+++ b/monst-game/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>モンスト風ミニゲーム</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="game-wrapper">
+        <div class="scoreboard">残りモンスター: <span id="score">0</span></div>
+        <canvas id="gameCanvas" width="400" height="400"></canvas>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/monst-game/script.js
+++ b/monst-game/script.js
@@ -1,0 +1,121 @@
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+const scoreEl = document.getElementById('score');
+
+const player = { x: 200, y: 350, r: 15, vx: 0, vy: 0, color: '#4285f4' };
+const enemies = [
+    { x: 100, y: 80, r: 15, color: '#e84545' },
+    { x: 200, y: 120, r: 15, color: '#e84545' },
+    { x: 300, y: 80, r: 15, color: '#e84545' }
+];
+scoreEl.textContent = enemies.length;
+
+let dragging = false;
+let dragStart = { x: 0, y: 0 };
+let dragEnd = { x: 0, y: 0 };
+
+function getMousePos(evt) {
+    const rect = canvas.getBoundingClientRect();
+    return {
+        x: evt.clientX - rect.left,
+        y: evt.clientY - rect.top
+    };
+}
+
+canvas.addEventListener('mousedown', (e) => {
+    const pos = getMousePos(e);
+    const dx = pos.x - player.x;
+    const dy = pos.y - player.y;
+    if (Math.sqrt(dx * dx + dy * dy) <= player.r) {
+        dragging = true;
+        dragStart = pos;
+        dragEnd = pos;
+    }
+});
+
+canvas.addEventListener('mousemove', (e) => {
+    if (dragging) {
+        dragEnd = getMousePos(e);
+    }
+});
+
+canvas.addEventListener('mouseup', (e) => {
+    if (dragging) {
+        const pos = getMousePos(e);
+        player.vx = (dragStart.x - pos.x) / 10;
+        player.vy = (dragStart.y - pos.y) / 10;
+        dragging = false;
+    }
+});
+
+function update() {
+    player.x += player.vx;
+    player.y += player.vy;
+    player.vx *= 0.99;
+    player.vy *= 0.99;
+
+    // bounds
+    if (player.x - player.r < 0) {
+        player.x = player.r;
+        player.vx *= -1;
+    }
+    if (player.x + player.r > canvas.width) {
+        player.x = canvas.width - player.r;
+        player.vx *= -1;
+    }
+    if (player.y - player.r < 0) {
+        player.y = player.r;
+        player.vy *= -1;
+    }
+    if (player.y + player.r > canvas.height) {
+        player.y = canvas.height - player.r;
+        player.vy *= -1;
+    }
+
+    // enemy collisions
+    for (let i = enemies.length - 1; i >= 0; i--) {
+        const e = enemies[i];
+        const dx = e.x - player.x;
+        const dy = e.y - player.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < e.r + player.r) {
+            enemies.splice(i, 1);
+            scoreEl.textContent = enemies.length;
+        }
+    }
+}
+
+function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    // draw enemies
+    enemies.forEach(e => {
+        ctx.beginPath();
+        ctx.arc(e.x, e.y, e.r, 0, Math.PI * 2);
+        ctx.fillStyle = e.color;
+        ctx.fill();
+    });
+
+    // draw player
+    ctx.beginPath();
+    ctx.arc(player.x, player.y, player.r, 0, Math.PI * 2);
+    ctx.fillStyle = player.color;
+    ctx.fill();
+
+    // draw drag line
+    if (dragging) {
+        ctx.beginPath();
+        ctx.moveTo(player.x, player.y);
+        ctx.lineTo(dragEnd.x, dragEnd.y);
+        ctx.strokeStyle = '#333';
+        ctx.stroke();
+    }
+}
+
+function loop() {
+    update();
+    draw();
+    requestAnimationFrame(loop);
+}
+
+loop();

--- a/monst-game/style.css
+++ b/monst-game/style.css
@@ -1,0 +1,24 @@
+body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    background: #f0f0f0;
+    margin: 0;
+}
+
+.game-wrapper {
+    text-align: center;
+}
+
+.scoreboard {
+    margin-bottom: 10px;
+    font-size: 18px;
+    font-family: sans-serif;
+}
+
+canvas {
+    background: #fff;
+    border: 2px solid #333;
+    border-radius: 8px;
+}

--- a/next-app/app/page.tsx
+++ b/next-app/app/page.tsx
@@ -12,7 +12,7 @@ export default function Home() {
           スイカゲームライク
         </Link>
         <Link
-          href="/monst-game/"
+          href="/monst-game"
           className="bg-blue-600 text-white px-4 py-2 rounded"
         >
           モンスト風ミニゲーム

--- a/next-app/app/page.tsx
+++ b/next-app/app/page.tsx
@@ -4,12 +4,20 @@ export default function Home() {
   return (
     <div className="max-w-sm mx-auto min-h-screen flex flex-col items-center justify-center p-4">
       <h1 className="text-2xl mb-6">サンプルゲームス</h1>
-      <Link
-        href="/games/suika"
-        className="bg-green-600 text-white px-4 py-2 rounded"
-      >
-        スイカゲームライク
-      </Link>
+      <div className="flex flex-col gap-4">
+        <Link
+          href="/games/suika"
+          className="bg-green-600 text-white px-4 py-2 rounded"
+        >
+          スイカゲームライク
+        </Link>
+        <Link
+          href="/monst-game/"
+          className="bg-blue-600 text-white px-4 py-2 rounded"
+        >
+          モンスト風ミニゲーム
+        </Link>
+      </div>
     </div>
   );
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,9 @@
 {
   "version": 2,
   "builds": [{ "src": "next-app/package.json", "use": "@vercel/next" }],
-  "routes": [{ "src": "/(.*)", "dest": "next-app/$1" }]
+  "routes": [
+    { "src": "/monst-game", "dest": "monst-game/index.html" },
+    { "src": "/monst-game/(.*)", "dest": "monst-game/$1" },
+    { "src": "/(.*)", "dest": "next-app/$1" }
+  ]
 }


### PR DESCRIPTION
## Summary
- add `monst-game` canvas mini game with drag-and-release controls
- document static game demos in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689557b0649483248e9c173ffdee81d2